### PR TITLE
Use infinitive wording as call-to-action button

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -5,7 +5,7 @@
       <h1 class="description">YOURLS Documentation</h1>
       <p class="actions">
         <a class="get-started" href="/guide/introduction.html">
-          Getting Started
+          Get Started
           <svg
             class="icon"
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
This is quite minor but still important as it's enforcing proper and simple English as much as possible.
This also match the most usual wording for call-to-action button in documentation.