### PR TITLE
Update instructions for making Apache enforce HTTPS

### DIFF
--- a/docs/guide/server-configuration.md
+++ b/docs/guide/server-configuration.md
@@ -46,8 +46,9 @@ RewriteRule ^.*$ /somedir/yourls-loader.php [L]
 
 ### Redirect everything from HTTP to HTTPS
 
-Add this extra line right after the `RewriteBase` line: `RewriteCond %{HTTPS} !=on`
-(Example [here](https://github.com/YOURLS/YOURLS/issues/2578#issuecomment-554732802))
+Add `RewriteCond %{HTTPS} off` and `RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]`
+before the `RewriteBase /` rule in your Apache configuration.
+(Full example [here](https://github.com/YOURLS/YOURLS/issues/2578#issuecomment-612451531))
 
 ### Give YOURLS its own directory
 


### PR DESCRIPTION
Discussion after the old suggestion linked indicates that it generates 404 errors, like described in YOURLS/YOURLS#3704. Further comments give this alternative approach, supported by thankful messages from other users who used it.