### PR TITLE
Remove day from translation tutorial post slug

### DIFF
--- a/blog/2013-02-15-yourls-workshop-translation/index.md
+++ b/blog/2013-02-15-yourls-workshop-translation/index.md
@@ -4,7 +4,7 @@ authors:
   - ozh
 tags:
   - tutorial
-slug: /2013/02/15/workshop-how-to-create-your-own-translation-file-for-yourls
+slug: /2013/02/workshop-how-to-create-your-own-translation-file-for-yourls
 ---
 
 Since version 1.6 YOURLS is fully "localizable", ie translatable, and the translation process itself is very simple. We're going to create a translation file, but first, a very little theory.


### PR DESCRIPTION
Existing links to this post on the old blog domain use only /yyyy/mm/, no dd/ at the end.

x-ref https://github.com/YOURLS/website/pull/354#issuecomment-3262467764